### PR TITLE
Update XComStrategyTuning.ini

### DIFF
--- a/LW_WeaponPack/Config/XComStrategyTuning.ini
+++ b/LW_WeaponPack/Config/XComStrategyTuning.ini
@@ -46,6 +46,24 @@ PointsToComplete=9000
 [AdvancedLaserWeaponsTech_LW_Diff_3 X2TechTemplate]
 PointsToComplete=5000
 
+[AssaultRifle_LS_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+
+[SMG_LS_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=20), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+
+[Cannon_LS_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+
+[Shotgun_LS_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+
+[SniperRifle_LS_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=25), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+
+[Pistol_LS_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=5), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=1), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=1))
+
 ; Coil
 
 [AssaultRifle_CG_Schematic_Diff_3 X2SchematicTemplate]
@@ -73,4 +91,19 @@ PointsToComplete=18000
 PointsToComplete=10000
 
 [AssaultRifle_CG_Diff_3 X2WeaponTemplate]
-; INDIVIDUAL WEAPON COSTS TODO
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=50), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+
+[SMG_CG_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=55), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+
+[Cannon_CG_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+
+[Shotgun_CG_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=5))
+
+[SniperRifle_CG_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=60), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=10))
+
+[Pistol_CG_Diff_3 X2WeaponTemplate]
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=30), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))


### PR DESCRIPTION
Includes all squad upgrade costs and individual weapon costs for Laser and Beam weapons for Legend difficulty. Also includes SMG squad upgrade costs for Magnetic and Beam weapons in Legend. 

Does not include individual weapon weapon costs for Magnetic and Beam weapons, as that is not included in this weapon pack.